### PR TITLE
Updated IRQ request to avoid IRQ loosing

### DIFF
--- a/rpi_power_switch/rpi_power_switch.c
+++ b/rpi_power_switch/rpi_power_switch.c
@@ -374,7 +374,7 @@ int __init rpi_power_switch_init(void)
 	 */
 	ret = request_irq(__gpio_to_irq(gpio_pin), power_isr,
 			  gpio_pol?IRQF_TRIGGER_RISING:IRQF_TRIGGER_FALLING,
-			  "Power button", NULL);
+			  "Power button", __gpio_to_irq(gpio_pin));
 	if (ret) {
 		pr_err("Unable to request IRQ\n");
 		goto out3;


### PR DESCRIPTION
On some condition, when driver initialize, IRQ is forgotten/deleted by system. Power switch is no longer useable (no powerdown when clicking. Kernel detect clicking, but can send an IRQ as it does not longer exist). Main cause is IRQ request is not link with a cookie, allowing any to delete it. When setting a cookie, everything works fine.
