### PR TITLE
Raspberry Pi 2 support

### DIFF
--- a/rpi_power_switch/Makefile
+++ b/rpi_power_switch/Makefile
@@ -5,16 +5,16 @@ PWD := $(shell pwd)
 ARCH := $(shell grep -Po '^Hardware\s*:\s*\K[[:alnum:]]{7}' /proc/cpuinfo)
 
 ifeq ($(ARCH),BCM2709)
-        PITYPE :=  CFLAGS=-DCONFIG_ARCH_BCM2709=y
+	PITYPE :=  CFLAGS=-DCONFIG_ARCH_BCM2709=y
 endif
 
 
 all:
-        $(MAKE) -C $(KDIR) M=$(PWD) $(PITYPE) modules
+	$(MAKE) -C $(KDIR) M=$(PWD) $(PITYPE) modules
 
 clean:
-        $(MAKE) -C $(KDIR) M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(PWD) clean
 
 install:
-        $(MAKE) -C $(KDIR) M=$(PWD) modules_install
+	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
 

--- a/rpi_power_switch/Makefile
+++ b/rpi_power_switch/Makefile
@@ -2,12 +2,19 @@
 obj-m := rpi_power_switch.o
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
+ARCH := $(shell grep -Po '^Hardware\s*:\s*\K[[:alnum:]]{7}' /proc/cpuinfo)
+
+ifeq ($(ARCH),BCM2709)
+        PITYPE :=  CFLAGS=-DCONFIG_ARCH_BCM2709=y
+endif
+
 
 all:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+        $(MAKE) -C $(KDIR) M=$(PWD) $(PITYPE) modules
 
 clean:
-	$(MAKE) -C $(KDIR) M=$(PWD) clean
+        $(MAKE) -C $(KDIR) M=$(PWD) clean
 
 install:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+        $(MAKE) -C $(KDIR) M=$(PWD) modules_install
+


### PR DESCRIPTION
Added Raspberry Pi 2 support for rpi_power-switch.

Allow either:
* Auto compilation for both pi and pi 2 hardware using make
* Adding rpi-module-switch in driver directory during full kernel compilation