### PR TITLE
Raspberry PI 2/3 pullup support

### DIFF
--- a/gpio_keys_device/gpio_keys_device.c
+++ b/gpio_keys_device/gpio_keys_device.c
@@ -111,7 +111,7 @@ static void gpio_pull(unsigned pin, unsigned pud)
 	/* set as input */
 	INP_GPIO(pin);
 	/* set pull tri/down/up */
-	*(gpio + GPIO_PUD) = pud & 3 ;		
+	*(gpio + GPIO_PUD) = pud & 3 ;
 	udelay(5);
 	*(gpio + GPIO_PUDCLK0 + (pin>31 ? 1 : 0) ) = 1 << (pin & 31);
 	udelay(5);

--- a/gpio_keys_device/gpio_keys_device.c
+++ b/gpio_keys_device/gpio_keys_device.c
@@ -89,13 +89,21 @@ static struct platform_device gpio_keys_device = {
 	},
 };
 
-#ifdef CONFIG_ARCH_BCM2708
+#if defined(CONFIG_ARCH_BCM2708) || defined(CONFIG_ARCH_BCM2709)
+
+//Pi or Pi2 architecture?
+#ifdef CONFIG_ARCH_BCM2709
+#define BCM2708_PERI_BASE       0x3F000000
+#else
+#define BCM2708_PERI_BASE       0x20000000
+#endif
+
 static void gpio_pull(unsigned pin, unsigned pud)
 {
 #define	GPIO_PUD     37
 #define	GPIO_PUDCLK0 38
 #define INP_GPIO(g) *(gpio+((g)/10)) &= ~(7<<(((g)%10)*3))
-	u32 *gpio = ioremap(0x20200000, SZ_16K);
+	u32 *gpio = ioremap(BCM2708_PERI_BASE + 0x200000, SZ_16K);
 
 	if (verbose > 1)
 		pr_info(DRVNAME": %s(%d, %d)\n", __func__, pin, pud);


### PR DESCRIPTION
Verified with raspberry-pi 3 with PiTFT GPIO buttons:

```
sudo insmod gpio_keys_device.ko  keys=22:108,27:105,17:106,23:103  pullup=1 active_low=1
```

Lovingly ripped from `rpi_power_switch`