### PR TITLE
It looks like they changed the CONFIG_ARCH_ name on newer kernels

### DIFF
--- a/gpio_keys_device/gpio_keys_device.c
+++ b/gpio_keys_device/gpio_keys_device.c
@@ -89,7 +89,7 @@ static struct platform_device gpio_keys_device = {
 	},
 };
 
-#if defined(CONFIG_ARCH_BCM2708) || defined(CONFIG_ARCH_BCM2709)
+#if defined(CONFIG_ARCH_BCM2708) || defined(CONFIG_ARCH_BCM2709) || defined(CONFIG_ARCH_BCM2835)
 
 //Pi or Pi2 architecture?
 #ifdef CONFIG_ARCH_BCM2709


### PR DESCRIPTION
I only patched the gpio_keys_device.c because that is the only tool I tested